### PR TITLE
Use app-token for dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Dry run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app.outputs.token }}
         run: yarn && yarn run release -d -b ${{ steps.branch.outputs.short_ref }}
 
       - name: Release


### PR DESCRIPTION
Currently the release dry-run fails because of missing GITHUB token. Use app-token for dry-run as well.