### PR TITLE
chore(ci): remove support for node-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12', '14', '16']
+        node-version: ['14', '16']
     steps:
       - uses: actions/checkout@v3.1.0
 


### PR DESCRIPTION
Signed-off-by: Jeroen Knoops <jeroen.knoops@philips.com>