### PR TITLE
Fix cleanup behavior change node16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           org: philips-software
 
       - name: Extract branch name
-        run: echo ::set-output name=short_ref::${GITHUB_REF#refs/*/}
+        run: echo "short_ref=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
         id: branch
 
       - name: Dry run release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+ * Changed fs.rmdir usage to fs.rm per deprication warning `[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead`
+ * Fixed error in action cleanup if action is used multiple times:
+   * Behavoir of recursive fs.rmdir has changed between node12 and node16: In node12, no error was returned if path does not exist (which is the case for the second cleanup of the action). In node16, a 'path does not exist' error is raised if the path does not exist.
+ * changed `set-output` usage per [github deprication warning](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+
 ## [1.3.0](https://github.com/philips-software/inner-source-checkout-action/compare/v1.2.1...v1.3.0) (2022-12-14)
 
 

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -2748,7 +2748,7 @@ function cleanup() {
         try {
             yield new Promise((resolve, reject) => {
                 core.info(`Removing private / inner source actions dir: ${baseDir}`);
-                fs.rmdir(baseDirPath, { recursive: true }, (error) => {
+                fs.rm(baseDirPath, { recursive: true, force: true }, (error) => {
                     if (error) {
                         reject(error);
                     }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -10,7 +10,7 @@ async function cleanup(): Promise<void> {
   try {
     await new Promise((resolve, reject) => {
       core.info(`Removing private / inner source actions dir: ${baseDir}`);
-      fs.rmdir(baseDirPath, { recursive: true }, (error) => {
+      fs.rm(baseDirPath, { recursive: true, force: true }, (error) => {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
Using this action multiple times with the same base-dir in a project causes an error to be generated when the cleanup action is run multiple times. In Node 12 (previous release), this was possible as the cleanup function using fs.rmdir did not return an error if the path does not exist. This behavior changed in Node 16: if the path does not exist, fs.rmdir does throw an error. Adding the option `force:true` results in the same behavior for Node 16 as in Node 12.

Additionally fixes:
 * the node deprecation warning for `fs.rmdir` is addressed by using `fs.rm` instead.
 * the `set-output` usage deprecation warning in the ci workflow-file is addressed
